### PR TITLE
chore: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # test step will be enabled in #8 (Jest setup)
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Adds `ci.yml` workflow that runs on push to `main` and on PRs
- Steps: lint → typecheck → build
- Lint uses `--if-present` so it's a no-op until #6 merges into main
- Test step will be wired up in #8 (Jest setup)

## Notes
- Once this PR merges, add `ci` as a required status check in branch protection settings
- Merge order: #21 (ESLint) → this PR → lint step activates automatically

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Established automated continuous integration workflow that runs on pull requests and pushes to the main branch, including dependency installation, linting, type checking, and build validation to maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->