### PR TITLE
docs: add minimal CLAUDE.md referencing root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# chorbit-server
+
+Shared behavioral rules, workflow, and git conventions live in the root `CLAUDE.md` one directory up, at `chorbit/CLAUDE.md`.
+
+@../CLAUDE.md
+
+Repo-specific stack, commands, and gotchas live in `README.md`.


### PR DESCRIPTION
Adds a thin `CLAUDE.md` at the repo root that imports the shared root file at `chorbit/CLAUDE.md`. Keeps all behavioral rules in one place while letting Claude Code pick them up when launched from inside this repo.

See also: Chorebit/chorbit-client#20

Closes #26